### PR TITLE
Add vitest tests for sanitize function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # helmets
 
+Run unit tests with:
+
+```
+npm test
+```
+

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "node node_modules/vite/bin/vite.js build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "canvas-confetti": "^1.6.0",

--- a/src/GameComponent.test.ts
+++ b/src/GameComponent.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeNodeToFile } from './GameComponent';
+
+// these tests verify sanitizeNodeToFile handles spaces, punctuation and ampersands
+
+describe('sanitizeNodeToFile', () => {
+  it('converts simple names', () => {
+    expect(sanitizeNodeToFile('Tom Brady')).toBe('tom_brady.avif');
+  });
+
+  it('handles punctuation and trimming', () => {
+    expect(sanitizeNodeToFile('  Hello, World! ')).toBe('hello_world.avif');
+  });
+
+  it('preserves numbers', () => {
+    expect(sanitizeNodeToFile('Player123')).toBe('player123.avif');
+  });
+
+  it('replaces ampersands with "and"', () => {
+    expect(sanitizeNodeToFile('A&B Co.')).toBe('aandb_co.avif');
+  });
+
+  it('collapses multiple separators', () => {
+    expect(sanitizeNodeToFile('cool--player')).toBe('cool_player.avif');
+  });
+});

--- a/src/GameComponent.tsx
+++ b/src/GameComponent.tsx
@@ -25,7 +25,7 @@ function getDateKey(date: Date) {
   return date.toLocaleDateString("en-US", { timeZone: "America/New_York" });
 }
 
-function sanitizeNodeToFile(node: string) {
+export function sanitizeNodeToFile(node: string) {
   return (
     node
       .replace(/&/g, "and")


### PR DESCRIPTION
## Summary
- export `sanitizeNodeToFile` so it can be tested
- add Vitest tests for edge cases
- add `test` script and document in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888454d98a4832790d9fd4196a70714