### PR TITLE
Fix CSV import of Teams

### DIFF
--- a/src/AdminPanel.tsx
+++ b/src/AdminPanel.tsx
@@ -50,13 +50,15 @@ export default function AdminPanel() {
             if (!isNaN(parsed)) pathLevel = parsed;
           }
 
+          const rawTeams = row["teams"] ?? row["Teams"] ?? "";
+
           return {
             name: row["name"] || row["Name"] || "",
             college: row["college"] || row["College"] || "",
             position: row["position"] || row["Position"] || "",
             teams:
-              typeof row["teams"] === "string"
-                ? row["teams"].split(",").map((s) => s.trim())
+              typeof rawTeams === "string"
+                ? rawTeams.split(",").map((s) => s.trim())
                 : [],
             difficulty: Number(row["difficulty"] ?? row["Difficulty"] ?? 1),
             path: pathArr,


### PR DESCRIPTION
## Summary
- allow capital `Teams` column when importing players in the admin panel

## Testing
- `npm run build` *(fails: platform-specific esbuild)*

------
https://chatgpt.com/codex/tasks/task_e_68883e5606308327be955b6a63db9fd0